### PR TITLE
add `omitempty` to ConfirmationBlockObject.Deny

### DIFF
--- a/block_object.go
+++ b/block_object.go
@@ -177,7 +177,7 @@ type ConfirmationBlockObject struct {
 	Title   *TextBlockObject `json:"title"`
 	Text    *TextBlockObject `json:"text"`
 	Confirm *TextBlockObject `json:"confirm"`
-	Deny    *TextBlockObject `json:"deny"`
+	Deny    *TextBlockObject `json:"deny,omitempty"`
 	Style   Style            `json:"style,omitempty"`
 }
 


### PR DESCRIPTION
This PR adds `omitempty` to `ConfirmationBlockObject.Deny`.

It's not a required field and without `omitempty` a `null` ends up being generated in the json payload, which is not accepted by the schema. This means that, with the current version of the client, it's not possible to omit the deny button.  